### PR TITLE
Rust: strip binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ zig.wasm: main.zig
 	zig build-exe -target wasm32-wasi-musl -O ReleaseFast $< -femit-bin=$@
 
 rust.wasm: main.rs
-	rustc $< -O --target wasm32-wasi -o $@
+	rustc $< -O -C strip=symbols --target wasm32-wasi -o $@
 
 d.wasm: main.d
 	ldc2 \


### PR DESCRIPTION
this patch makes rust.wasm bit smaller

```
-rwxrwxr-x 1 kubo39 kubo39   32914 Apr 10 22:16 d.wasm
-rwxrwxr-x 1 kubo39 kubo39 1669948 Apr 10 22:16 go.wasm
-rwxrwxr-x 1 kubo39 kubo39   88082 Apr 10 22:16 rust.wasm
-rwxr--r-- 1 kubo39 kubo39  572990 Apr 10 22:16 zig.wasm
```