### PR TITLE
D: shrink binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ d.wasm: main.d
 		--mtriple=wasm32-unknown-wasi \
 		-Oz \
 		--betterC \
+		--fvisibility=hidden \
 		-L$(WASI_SDK)/lib/clang/17/lib/wasi/libclang_rt.builtins-wasm32.a \
 		-L$(WASI_SDK)/share/wasi-sysroot/lib/wasm32-wasi/crt1.o \
 		-L$(WASI_SDK)/share/wasi-sysroot/lib/wasm32-wasi/libc.a \

--- a/main.d
+++ b/main.d
@@ -4,7 +4,7 @@ nothrow:
 
 enum EX_SOFTWARE = 70;
 
-__gshared int errno;
+extern int errno;
 void _Exit(int status) @trusted;
 void perror(const char* s) @trusted;
 pragma(printf) int printf(const(char)* format, ...) @trusted;


### PR DESCRIPTION
- `extern int errno`: allows to use errno in libc, and reduces globals section(8bytes) and exports section(8bytes).
- `--fvisibility=hidden`: reduces export section(25bytes).